### PR TITLE
Basic Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,9 +1,16 @@
 use ExtUtils::MakeMaker;
  
 WriteMakefile(
-    NAME    => 'Stasis',
-    VERSION => '0.01',
-    AUTHOR => 'David Farrell',
-    LICENSE => 'FreeBSD',
+    NAME      => 'Stasis',
+    VERSION   => '0.01',
+    AUTHOR    => 'David Farrell',
+    LICENSE   => 'FreeBSD',
     EXE_FILES => [qw(stasis)],
+    PREREQ_PM => {
+        'autodie'       => 0,
+        'Time::Piece'   => 0,
+        'Time::Seconds' => 0,
+        'Getopt::Long'  => 0,
+        'Pod::Usage'    => 0,
+    }
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,9 @@
+use ExtUtils::MakeMaker;
+ 
+WriteMakefile(
+    NAME    => 'Stasis',
+    VERSION => '0.01',
+    AUTHOR => 'David Farrell',
+    LICENSE => 'FreeBSD',
+    EXE_FILES => [qw(stasis)],
+);


### PR DESCRIPTION
I have created the most basic `Makefile.PL` I could whip up. The `Makefile.PL` requires only [ExtUtils::MakeMaker](https://metacpan.org/pod/ExtUtils::MakeMaker), which is in core and has been there since **Perl 5** initial release (according to [Module::CoreList](https://metacpan.org/pod/distribution/Module-CoreList/lib/Module/CoreList.pod)).

jonasbn
